### PR TITLE
Updated README to include latest install instructions for Mac OSX. Inclu...

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -117,34 +117,14 @@ repository:
 
 For css_doc to work, you need the latest version of CSSPool (2.0.0). CSSPool depends on libcroco, which can be installed on OS X via
 
- $ sudo port install libcroco
+ $ brew install libcroco
 
-Unfortunately, at the time of this writing, libcroco contains a bug, which is essential to css_doc: it does not parse comments, but instead it simply ignores them. The libcroco authors have already been notified of this bug, and will hopefully release a fixed version soon.
+To download the latest version of libcroco which is v0.6.8, and can be located at http://ftp.gnome.org/pub/gnome/sources/libcroco/0.6/, edit the latest Homebrew formula to include the following:
 
-To make things work, download a copy of libcroco from
+    url 'http://ftp.gnome.org/pub/GNOME/sources/libcroco/0.6/libcroco-0.6.8.tar.xz'
+    sha256 'ea6e1b858c55219cefd7109756bff5bc1a774ba7a55f7d3ccd734d6b871b8570'
 
-  http://ftp.gnome.org/pub/gnome/sources/libcroco/0.6/
-  
-(preferably version 0.6.2), and add the following lines to src/cr-parser.c, line 630, between "do { if (token) {" and "cr_token_destroy(token)":
-
-  if (token->type == COMMENT_TK && PRIVATE (a_this)->sac_handler && PRIVATE (a_this)->sac_handler->comment) {
-      PRIVATE (a_this)->sac_handler->comment(PRIVATE (a_this)->sac_handler, token->u.str);
-  }
-
-Then, in the root directory of libcroco, compile using
-
-  $ ./configure
-  $ make
-
-You can use make install to install the library, but you can just as well set the environment variable LIBCROCO to
-
-  /path/to/libcroco/src/.libs/libcroco-0.6.dylib
-
-(on OS X), or
-
-  /path/to/libcroco/src/.libs/libcroco-0.6.so
-
-on other Unix systems.
+Then you can run the brew install command. That will install libcroco v0.6.8 which has apparently fixed the previous bug which prevented css-doc from utilizing csspool. (Issue can be found here: https://github.com/tkadauke/css_doc/issues/1)
 
 == Usage
 


### PR DESCRIPTION
Version 0.6.4 of `libcroco` contained a bug:

> which is essential to css_doc: it does not parse comments, but instead it simply ignores them..

The latest version of `libcroco` which is 0.6.8 has fixed that bug. By using Homebrew instead of Mac Ports and editing the Homebrew Formula you are able to edit the URL and SHA256 lines and download and install a proper libcroco. 

I've found various forks of this project but nobody has updated their install instructions which lead to a good 20-30 minutes of tinkering with it before I was able to use cssdoc on OSX.

Signed-off-by: Joshua Canfield jcanfield@creativeboulder.com
